### PR TITLE
Fix model.reduce()

### DIFF
--- a/src/jaxsim/high_level/model.py
+++ b/src/jaxsim/high_level/model.py
@@ -327,8 +327,9 @@ class Model(JaxsimDataclass):
 
         # Keep original base link pose if specified
         if not reset_base_pose:
-            self.base_position = original_position
-            self.base_transform = original_transform
+            self._set_mutability(mutability=self._mutability().MUTABLE_NO_VALIDATION)
+            self.reset_base_position(original_position)
+            self.reset_base_transform(original_transform)
 
         self._links = reduced_model._links
         self._joints = reduced_model._joints


### PR DESCRIPTION
When `self.data = reduced_model.data` is called, the `Model` class inherit the same `_mutability()` as the one of the `reduced_model` therefore it was impossible to call `reset_base_position`, which acts directly on the attribute `model.data.model_state.base_position`. 

Now the `mutability` is restored after evaluating the expression on line 326 and the `reduce()` method can now keep the same initial base configuration of the original model.