### PR TITLE
Fix inheritance issue for `model.reduce()` method

### DIFF
--- a/src/jaxsim/high_level/model.py
+++ b/src/jaxsim/high_level/model.py
@@ -327,8 +327,9 @@ class Model(JaxsimDataclass):
 
         # Keep original base link pose if specified
         if not reset_base_pose:
-            self.base_position = original_position
-            self.base_transform = original_transform
+            self._set_mutability(mutability=self._mutability().MUTABLE_NO_VALIDATION)
+            self.reset_base_position(original_position)
+            self.reset_base_transform(original_transform)
 
         self._links = reduced_model._links
         self._joints = reduced_model._joints


### PR DESCRIPTION
Following up from #3 as it mistakenly merged to main.